### PR TITLE
[PR] Chore: Prepare main branch for v0.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,19 @@
 # Changelog
 
-This changelog covers the major documentation and maintainability improvements. For future releases, please add entries for new features, bug fixes, and breaking changes. 
+All notable changes to this project will be documented in this file.
 
-All *notable* changes to this project are recorded here.
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] – 0.1.0
-
-- (future changes go here)
+## [Unreleased]
+- No pending changes.
 
 ## [0.1.0] – 2025-07-15
+
+### Security Warning ⚠️
+
+- This is an **experimental testnet release** and is **not safe for production use**.
+- It contains known timing-leak vulnerabilities inherited from upstream crates. Please see the [Security Policy](.github/SECURITY.md) for full details before using this software.
 
 ### Added
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,6 @@
 name = "quisquis-rust"
 version = "0.1.0"
 edition = "2021"
-authors = ["Twilight Project <hello@twilight-project.org>"]
 description = "A Rust implementation of Quisquis, a privacy-preserving cryptocurrency protocol"
 homepage = "https://github.com/twilight-project/quisquis-rust"
 repository = "https://github.com/twilight-project/quisquis-rust"

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,33 +1,43 @@
-+# Quisquis Protocol v0.1.0 Testnet Release Notes
-+
-+Released: 2025-07-15
-+
-+This initial public release of **quisquis-rust** is for research and testnet experimentation only. It contains known cryptographic vulnerabilities inherited from upstream crates and must not be used with real funds.
-+
-+## Highlights
-+
-+- Privacy-preserving accounts with ElGamal commitments and encrypted balance updates
-+- Ristretto group key operations (Curve25519)
-+- Range proofs via Bulletproofs for confidential balances
-+- Cryptographic shuffle protocols for transaction anonymity
-+- Example binaries and extensive API documentation
-+
-+See the [CHANGELOG](CHANGELOG.md) for a full list of additions.
-+
-+## Security Status
-+
-+- **Testnet-only** build with timing-leak issues in `curve25519-dalek v3.2.1` and `ed25519-dalek v1.0.1`
-+- Fixes are scheduled for **v0.2.0**; see [SECURITY.md](.github/SECURITY.md) for details
-+- Do **not** use this release in production or to protect real value
-+
-+## Getting Started
-+
-+1. Clone the repository and build from source:
-+   ```bash
-+   git clone https://github.com/twilight-project/quisquis-rust.git
-+   cd quisquis-rust
-+   cargo build --release
-+   ```
-+2. Explore the example binaries and API documentation to test the protocol on a local testnet.
-+
-+Feedback and contributions are welcome! Please review the [CONTRIBUTING guide](.github/CONTRIBUTING.md) for development tips and the release checklist.
+# Quisquis Protocol v0.1.0 Testnet Release Notes
+
+**Released:** 2025-07-15
+
+This initial public release of **quisquis-rust** is for research and testnet experimentation only.  
+It contains known cryptographic vulnerabilities inherited from upstream crates and **must not be used with real funds**.
+
+---
+
+## Highlights
+
+- Privacy-preserving accounts with ElGamal commitments and encrypted balance updates
+- Ristretto group key operations (Curve25519)
+- Range proofs via Bulletproofs for confidential balances
+- Cryptographic shuffle protocols for transaction anonymity
+- Example binaries and extensive API documentation
+
+See the [CHANGELOG](CHANGELOG.md) for a full list of additions.
+
+---
+
+## Security Status
+
+- **Testnet-only** build with timing-leak issues in `curve25519-dalek v3.2.1` and `ed25519-dalek v1.0.1`
+- Fixes are scheduled for **v0.2.0**; see [SECURITY.md](.github/SECURITY.md) for details
+- **Do not use this release in production or to protect real value**
+
+---
+
+## Getting Started
+
+1. **Clone the repository and build from source:**
+   ```bash
+   git clone https://github.com/twilight-project/quisquis-rust.git
+   cd quisquis-rust
+   cargo build --release
+   ```
+2. **Explore the example binaries and API documentation** to test the protocol on a local testnet.
+
+---
+
+Feedback and contributions are welcome!  
+Please review the [CONTRIBUTING guide](.github/CONTRIBUTING.md) for development tips and the release checklist.


### PR DESCRIPTION
This pull request merges the `develop` branch into `main` to prepare for the upcoming `v0.1.0` release. The primary focus of these changes is to update project documentation, dependency management, and release artifacts to ensure clarity, maintainability, and security transparency.

There are no functional code changes in this PR; it is purely for maintenance and documentation ahead of creating the new release tag.

Key changes include:
- **Revised `CHANGELOG.md`**: Updated to strictly follow the "Keep a Changelog" format and Semantic Versioning. A prominent security warning has also been added to the `v0.1.0` entry to alert users to the known issues in the initial testnet release.
- **Improved `RELEASE_NOTES.md`**: The formatting has been clarified to render correctly as Markdown, and security warnings have been made more explicit.
- **Cleaned `Cargo.toml`**: Removed the `authors` field to streamline maintainability and rely on the `[contributors]` section of the manifest.
- **Dependency Management**: Updated dependencies (`hex`, `zkschnorr` tag) and configured `deny.toml` to formally allow the required Git sources.

**Type of change**
- [ ] Bug fix
- [ ] New feature
- [X] Documentation update
- [X] Other (please describe): **Release Preparation & Maintenance**

**Checklist**
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works *(N/A for this change)*
- [X] New and existing unit tests pass locally with my changes

**Additional notes**
This merge prepares the `main` branch to be tagged as `v0.1.0` and `Testnet-v1.0.0`. Once this PR is merged, the new tags can be created from the `main` branch and the corresponding GitHub releases can be published.